### PR TITLE
Refactor indexing to display as 1-indexed

### DIFF
--- a/www/main.tsx
+++ b/www/main.tsx
@@ -81,10 +81,13 @@ function MenuBar(props: MenuBarProps) {
       {numFunctions > 1 && <div>
         Function <input
           type="number"
-          value={funcIndex}
+          min="1"
+          max={numFunctions}
+          value={funcIndex + 1}
           className="ig-w3"
           onChange={e => {
-            const newFuncIndex = Math.max(0, Math.min(numFunctions - 1, parseInt(e.target.value, 10)));
+            const displayValue = parseInt(e.target.value, 10);
+            const newFuncIndex = Math.max(0, Math.min(numFunctions - 1, displayValue - 1));
             setFuncIndex(isNaN(newFuncIndex) ? 0 : newFuncIndex);
           }}
         /> / {numFunctions}


### PR DESCRIPTION
Internally, the function index is 0 indexed, but displays as being 1
indexed. This patch fixes that and also limits the funcIndex to be
within range of [1, numFunctions].

I noticed before that you could get the index to display as -1 or get
it to roll above the number of functions. This patch should fix that.
